### PR TITLE
Package needed by ubuntu 12.10

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -7,7 +7,7 @@ set -e
 ROOT=$(cd `dirname ${BASH_SOURCE[0]}` && echo $PWD)
 
 # We need the newest version of redis so we can use the batch function
-apt-get install -y --force-yes python-software-properties unzip
+apt-get install -y --force-yes python-software-properties unzip software-properties-common
 add-apt-repository -y ppa:rwky/redis
 apt-get update
 


### PR DESCRIPTION
Seems that package software-properties-common now has the utilities of add-apt-repository and apt-add-repository.

http://packages.ubuntu.com/quantal/all/software-properties-common/filelist
http://packages.ubuntu.com/quantal/all/python-software-properties/filelist
